### PR TITLE
Support for Exporting from 2- and 4-Channel Projects

### DIFF
--- a/image_extractor.py
+++ b/image_extractor.py
@@ -1,7 +1,4 @@
 import os
-import sys
-import syglass as sy
-from syglass import pyglass
 import numpy as np
 import tifffile
 import subprocess
@@ -16,9 +13,6 @@ def extract(project):
 
 	# Calculate the index of the highest resolution level
 	max_resolution_level = len(resolution_map) - 1
-
-	# Determine the number of blocks in this level
-	block_count = resolution_map[max_resolution_level]
 	
 	# get size of project       
 	total_size = project.get_size(max_resolution_level)
@@ -37,7 +31,12 @@ def extract(project):
 		block = project.get_custom_block(0, max_resolution_level, offset, dimensions)
 		data = block.data
 		print(s + ".tiff")
-		tifffile.imwrite(tail + "_" + s + ".tiff", data)
+		if (len(np.shape(data)) > 3):
+			data = np.swapaxes(data, 1, 3)
+			data = np.swapaxes(data, 2, 3)
+			tifffile.imwrite(tail + "_" + s + ".tiff", data, imagej=True, metadata={'axes': 'ZCYX'})
+		else:
+			tifffile.imwrite(tail + "_" + s + ".tiff", data)
 	subprocess.run(['explorer', head])
 
 def main(args):

--- a/image_extractor.py
+++ b/image_extractor.py
@@ -31,7 +31,8 @@ def extract(project):
 		block = project.get_custom_block(0, max_resolution_level, offset, dimensions)
 		data = block.data
 		print(s + ".tiff")
-		if (len(np.shape(data)) > 3):
+		channels = np.shape(data)[3]
+		if channels == 2 or channels == 4:
 			data = np.swapaxes(data, 1, 3)
 			data = np.swapaxes(data, 2, 3)
 			tifffile.imwrite(tail + "_" + s + ".tiff", data, imagej=True, metadata={'axes': 'ZCYX'})


### PR DESCRIPTION
This script was not working correctly for 2- and 4-channel projects:

- For 2-channel projects, it was exporting single-channel TIFF images with the incorrect dimensions. I've attached here an example of the old and new 2-channel output.
- For 4-channel projects, it was exporting an RBG (3-channel) images

[Here is a ZIP archive of the good and bad 2-channel outputs.](https://github.com/IstoVisio/script_image_extractor/files/8904077/two_channel_examples.zip)

Also removes a few unused imports and an unused local variable.